### PR TITLE
Fixed wrong spelling of dirname command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd $(dirnamr $0); set -xe
+cd $(dirname $0); set -xe
 # build
 
 docker build -t veilid-node:latest .

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 # run veilid
 
-cd $(dirnamr $0); set -xe
+cd $(dirname $0); set -xe
 
 docker rm -f veilid-node || true
 docker run -d --name veilid-node veilid-node:latest .

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,6 @@
 
 # test veilid
 
-cd $(dirnamr $0); set -xe
+cd $(dirname $0); set -xe
 
 docker run --rm -it veilid-node:latest


### PR DESCRIPTION
Typo in `dirname` command causing `build.sh` to fail.