### PR TITLE
Merge `latest` into `main` since `main` was empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:latest
+
+# install
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y wget gpg sudo systemd
+RUN wget -O- https://packages.veilid.net/gpg/veilid-packages-key.public | sudo gpg --dearmor -o /usr/share/keyrings/veilid-packages-keyring.gpg
+RUN dpkg --print-architecture && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/veilid-packages-keyring.gpg] https://packages.veilid.net/apt stable main" | sudo tee /etc/apt/sources.list.d/veilid.list
+RUN sudo apt update && \
+    sudo apt install -y veilid-server veilid-cli
+
+COPY entry.sh /entry.sh
+
+# sudo -u veilid veilid-server
+USER veilid
+
+# config
+VOLUME /config
+
+# State holds the node ID etc. to persist between runs
+VOLUME /root/.local/share/veilid/
+
+# logs
+VOLUME /logs
+
+# data
+VOLUME /var/db/veilid-server
+
+ENTRYPOINT ["/bin/bash", "/entry.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# veilid-node-docker
+
+Run a Veilid Node in docker
+
+## Install and run a Veilid Node standalone
+
+official: https://gitlab.com/veilid/veilid/-/blob/main/INSTALL.md
+
+## Install and run on docker
+
+```shell
+/bin/bash build.sh
+```
+
+```shell
+/bin/bash test.sh
+```
+
+```shell
+/bin/bash run.sh
+```

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd $(dirnamr $0); set -xe
+cd $(dirname $0); set -xe
 # build
 
 docker build -t veilid-node:latest .

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $(dirnamr $0); set -xe
+# build
+
+docker build -t veilid-node:latest .

--- a/entry.sh
+++ b/entry.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# entrypoint
+
+set -xe
+
+id
+
+RUST_BACKTRACE=1 RUST_BACKTRACE=full COLORBT_SHOW_HIDDEN=1 veilid-server

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 # run veilid
 
-cd $(dirnamr $0); set -xe
+cd $(dirname $0); set -xe
 
 docker rm -f veilid-node || true
 docker run -d --name veilid-node veilid-node:latest .

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# run veilid
+
+cd $(dirnamr $0); set -xe
+
+docker rm -f veilid-node || true
+docker run -d --name veilid-node veilid-node:latest .

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# test veilid
+
+cd $(dirnamr $0); set -xe
+
+docker run --rm -it veilid-node:latest

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,6 @@
 
 # test veilid
 
-cd $(dirnamr $0); set -xe
+cd $(dirname $0); set -xe
 
 docker run --rm -it veilid-node:latest


### PR DESCRIPTION
This just merges the `latest` branch into `main` so that the code is in the default branch. This lets people see the code on github without selecting the `latest` branch, as well as when they clone the repo.